### PR TITLE
Add links to the root catalog

### DIFF
--- a/disasters/hurricane-harvey/0831/20170831_162740_ssc1d1.json
+++ b/disasters/hurricane-harvey/0831/20170831_162740_ssc1d1.json
@@ -68,6 +68,10 @@
       "href": "../../catalog.json"
     },
     {
+      "rel": "root",
+      "href": "../../catalog.json"
+    },
+    {
       "rel": "parent",
       "href": "../catalog.json"
     }

--- a/disasters/hurricane-harvey/0831/20170831_172754_101c.json
+++ b/disasters/hurricane-harvey/0831/20170831_172754_101c.json
@@ -63,6 +63,10 @@
       "href": "../../catalog.json"
     },
     {
+      "rel": "root",
+      "href": "../../catalog.json"
+    },
+    {
       "rel": "parent",
       "href": "catalog.json"
     }

--- a/disasters/hurricane-harvey/0831/20170831_195425_SS02.json
+++ b/disasters/hurricane-harvey/0831/20170831_195425_SS02.json
@@ -59,6 +59,10 @@
       "href": "../../catalog.json"
     },
     {
+      "rel": "root",
+      "href": "../../catalog.json"
+    },
+    {
       "rel": "parent",
       "href": "../catalog.json"
     }

--- a/disasters/hurricane-harvey/0831/20170831_195552_SS02.json
+++ b/disasters/hurricane-harvey/0831/20170831_195552_SS02.json
@@ -61,6 +61,10 @@
       "href": "../../catalog.json"
     },
     {
+      "rel": "root",
+      "href": "../../catalog.json"
+    },
+    {
       "rel": "parent",
       "href": "../catalog.json"
     }

--- a/disasters/hurricane-harvey/0831/catalog.json
+++ b/disasters/hurricane-harvey/0831/catalog.json
@@ -10,6 +10,7 @@
       "rel": "self",
       "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/catalog.json"
     },
+    { "rel": "root", "href": "../../catalog.json" },
     {
       "rel": "parent",
       "href": "../catalog.json"

--- a/disasters/hurricane-harvey/catalog.json
+++ b/disasters/hurricane-harvey/catalog.json
@@ -9,6 +9,7 @@
       "rel": "self",
       "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/catalog.json"
     },
+    { "rel": "root", "href": "../catalog.json" },
     {
       "rel": "parent",
       "href": "../catalog.json"

--- a/disasters/mount-mayon-volcano/catalog.json
+++ b/disasters/mount-mayon-volcano/catalog.json
@@ -9,6 +9,7 @@
       "rel": "self",
       "href": "http://cholmes.github.io/stac-html-x/disasters/mount-mayon/catalog.json"
     },
+    { "rel": "root", "href": "../catalog.json" },
     {
       "rel": "parent",
       "href": "../catalog.json"

--- a/disasters/santa-rosa-fires/catalog.json
+++ b/disasters/santa-rosa-fires/catalog.json
@@ -9,6 +9,7 @@
       "rel": "self",
       "href": "http://cholmes.github.io/stac-html-x/disasters/santa-rosa-fires/catalog.json"
     },
+    { "rel": "root", "href": "../catalog.json" },
     { "rel": "parent", "href": "../catalog.json" }
   ]
 }


### PR DESCRIPTION
Optional per https://github.com/radiantearth/stac-spec/blob/v0.6.0/item-spec/item-spec.md#relation-types, but helpful for catalogs to inherit keywords, license, providers from ancestors (since catalogs are not part of collections).