### PR TITLE
Make all links relative to the root catalog

### DIFF
--- a/disasters/catalog.json
+++ b/disasters/catalog.json
@@ -28,7 +28,6 @@
       "rel": "self",
       "href": "https://storage.googleapis.com/pdd-stac/disasters/catalog.json"
     },
-    { "rel": "root", "href": "catalog.json" },
     {
       "rel": "child",
       "href": "hurricane-harvey/catalog.json",

--- a/disasters/hurricane-harvey/0831/20170831_162740_ssc1d1.json
+++ b/disasters/hurricane-harvey/0831/20170831_162740_ssc1d1.json
@@ -61,7 +61,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/20170831_162740_ssc1d1.json"
+      "href": "20170831_162740_ssc1d1.json"
     },
     {
       "rel": "collection",
@@ -69,7 +69,8 @@
     },
     {
       "rel": "root",
-      "href": "../../catalog.json"
+      "href": "../../catalog.json",
+      "href:from": "hurricane-harvey/0831/20120170831_162740_ssc1d1.json"
     },
     {
       "rel": "parent",

--- a/disasters/hurricane-harvey/0831/20170831_172754_101c.json
+++ b/disasters/hurricane-harvey/0831/20170831_172754_101c.json
@@ -56,7 +56,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/20170831_172754_101c.json"
+      "href": "20170831_172754_101c.json"
     },
     {
       "rel": "collection",
@@ -64,7 +64,8 @@
     },
     {
       "rel": "root",
-      "href": "../../catalog.json"
+      "href": "../../catalog.json",
+      "href:from": "hurricane-harvey/0831/20170831_172754_101c.json"
     },
     {
       "rel": "parent",

--- a/disasters/hurricane-harvey/0831/20170831_195425_SS02.json
+++ b/disasters/hurricane-harvey/0831/20170831_195425_SS02.json
@@ -52,7 +52,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/20170831_195425_SS02.json"
+      "href": "20170831_195425_SS02.json"
     },
     {
       "rel": "collection",
@@ -60,7 +60,8 @@
     },
     {
       "rel": "root",
-      "href": "../../catalog.json"
+      "href": "../../catalog.json",
+      "href:from": "hurricane-harvey/0831/20170831_195425_SS02.json"
     },
     {
       "rel": "parent",

--- a/disasters/hurricane-harvey/0831/20170831_195552_SS02.json
+++ b/disasters/hurricane-harvey/0831/20170831_195552_SS02.json
@@ -54,7 +54,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/20170831_195552_SS02.json"
+      "href": "20170831_195552_SS02.json"
     },
     {
       "rel": "collection",
@@ -62,7 +62,8 @@
     },
     {
       "rel": "root",
-      "href": "../../catalog.json"
+      "href": "../../catalog.json",
+      "href:from": "hurricane-harvey/0831/20170831_195552_SS02.json"
     },
     {
       "rel": "parent",

--- a/disasters/hurricane-harvey/0831/Houston-East-20170831-103f-100d-0f4f-RGB.json
+++ b/disasters/hurricane-harvey/0831/Houston-East-20170831-103f-100d-0f4f-RGB.json
@@ -38,7 +38,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/Houston-East-20170831-103f-100d-0f4f-RGB.json"
+      "href": "Houston-East-20170831-103f-100d-0f4f-RGB.json"
     },
     {
       "rel": "collection",
@@ -46,7 +46,8 @@
     },
     {
       "rel": "parent",
-      "href": "../catalog.json"
+      "href": "../../catalog.json",
+      "href:from": "hurricane-harvey/0831/Houston-East-20170831-103f-100d-0f4f-RGB.json"
     }
   ],
 

--- a/disasters/hurricane-harvey/0831/catalog.json
+++ b/disasters/hurricane-harvey/0831/catalog.json
@@ -8,9 +8,13 @@
   "links": [
     {
       "rel": "self",
-      "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/catalog.json"
+      "href": "catalog.json"
     },
-    { "rel": "root", "href": "../../catalog.json" },
+    {
+      "rel": "root",
+      "href": "../../catalog.json",
+      "href:from": "hurricane-harvey/0831/catalog.json"
+    },
     {
       "rel": "parent",
       "href": "../catalog.json"

--- a/disasters/hurricane-harvey/catalog.json
+++ b/disasters/hurricane-harvey/catalog.json
@@ -7,9 +7,13 @@
   "links": [
     {
       "rel": "self",
-      "href": "https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/catalog.json"
+      "href": "catalog.json"
     },
-    { "rel": "root", "href": "../catalog.json" },
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "href:from": "hurricane-harvey/catalog.json"
+    },
     {
       "rel": "parent",
       "href": "../catalog.json"

--- a/disasters/mount-mayon-volcano/catalog.json
+++ b/disasters/mount-mayon-volcano/catalog.json
@@ -7,9 +7,13 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://cholmes.github.io/stac-html-x/disasters/mount-mayon/catalog.json"
+      "href": "catalog.json"
     },
-    { "rel": "root", "href": "../catalog.json" },
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "href:from": "mount-mayon/catalog.json"
+    },
     {
       "rel": "parent",
       "href": "../catalog.json"

--- a/disasters/santa-rosa-fires/catalog.json
+++ b/disasters/santa-rosa-fires/catalog.json
@@ -7,9 +7,13 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://cholmes.github.io/stac-html-x/disasters/santa-rosa-fires/catalog.json"
+      "href": "catalog.json"
     },
-    { "rel": "root", "href": "../catalog.json" },
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "href:from": "santa-rosa-fires/catalog.json"
+    },
     { "rel": "parent", "href": "../catalog.json" }
   ]
 }


### PR DESCRIPTION
Introduce `href:from` to indicate the path _from_ the root to the current document.

At this point, `self` becomes the filename and duplicates the filename portion of `href:from`, so that may indicate an additional direction.

The only absolute URL in this catalog is now the root catalog's `self`. That, too, could be removed and stashed in a sidecar file to be used for resolution.

Refs radiantearth/stac-spec#401